### PR TITLE
Electra focil fork choice + lints

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -350,7 +350,7 @@ jobs:
     - name: Check formatting with cargo fmt
       run: make cargo-fmt
     - name: Lint code for quality and style with Clippy
-      run: make lint
+      run: make lint-full
     - name: Certify Cargo.lock freshness
       run: git diff --exit-code Cargo.lock
     - name: Typecheck benchmark code without running it

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ test-full: cargo-fmt test-release test-debug test-ef test-exec-engine
 # Lints the code for bad style and potentially unsafe arithmetic using Clippy.
 # Clippy lints are opt-in per-crate for now. By default, everything is allowed except for performance and correctness lints.
 lint:
-	RUSTFLAGS="-C debug-assertions=no $(RUSTFLAGS)" cargo clippy --workspace --benches --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
+	cargo clippy --workspace --benches --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
 		-D clippy::fn_to_numeric_cast_any \
 		-D clippy::manual_let_else \
 		-D clippy::large_stack_frames \
@@ -219,6 +219,10 @@ lint:
 # Lints the code using Clippy and automatically fix some simple compiler warnings.
 lint-fix:
 	EXTRA_CLIPPY_OPTS="--fix --allow-staged --allow-dirty" $(MAKE) lint
+
+# Also run the lints on the optimized-only tests
+lint-full:
+	RUSTFLAGS="-C debug-assertions=no $(RUSTFLAGS)" $(MAKE) lint
 
 # Runs the makefile in the `ef_tests` repo.
 #

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7267,7 +7267,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         )
     }
 
-    pub async fn set_unsatisfied_inclusion_list_block(self: &Arc<Self>, block_root: Hash256) -> Result<(), Error> {
+    pub async fn set_unsatisfied_inclusion_list_block(
+        self: &Arc<Self>,
+        block_root: Hash256,
+    ) -> Result<(), Error> {
         let chain = self.clone();
         let fork_choice_result = self
             .spawn_blocking_handle(
@@ -7294,7 +7297,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     }
 
     pub fn on_verified_inclusion_list(&self, signed_il: SignedInclusionList<T::EthSpec>) {
-        self.inclusion_list_cache.write().on_inclusion_list(signed_il);
+        self.inclusion_list_cache
+            .write()
+            .on_inclusion_list(signed_il);
     }
 
     pub fn metrics(&self) -> BeaconChainMetrics {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -471,7 +471,7 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     /// A cache used when producing attestations whilst the head block is still being imported.
     pub early_attester_cache: EarlyAttesterCache<T::EthSpec>,
     /// A cache used to store verified/equivocating inclusion lists.
-    pub inclusion_list_cache: InclusionListCache<T::EthSpec>,
+    pub inclusion_list_cache: RwLock<InclusionListCache<T::EthSpec>>,
     /// Cache gossip verified blocks to serve over ReqResp before they are imported
     pub reqresp_pre_import_cache: Arc<RwLock<ReqRespPreImportCache<T::EthSpec>>>,
     /// A cache used to keep track of various block timings.
@@ -7291,6 +7291,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         Ok(())
+    }
+
+    pub fn on_verified_inclusion_list(&self, signed_il: SignedInclusionList<T::EthSpec>) {
+        self.inclusion_list_cache.write().on_inclusion_list(signed_il);
     }
 
     pub fn metrics(&self) -> BeaconChainMetrics {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -470,6 +470,8 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     pub(crate) attester_cache: Arc<AttesterCache>,
     /// A cache used when producing attestations whilst the head block is still being imported.
     pub early_attester_cache: EarlyAttesterCache<T::EthSpec>,
+    /// A cache used to store verified/equivocating inclusion lists.
+    pub inclusion_list_cache: InclusionListCache<T::EthSpec>,
     /// Cache gossip verified blocks to serve over ReqResp before they are imported
     pub reqresp_pre_import_cache: Arc<RwLock<ReqRespPreImportCache<T::EthSpec>>>,
     /// A cache used to keep track of various block timings.

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -10,7 +10,7 @@ use fork_choice::ForkChoiceStore;
 use proto_array::JustifiedBalances;
 use safe_arith::ArithError;
 use ssz_derive::{Decode, Encode};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use store::{Error as StoreError, HotColdDB, ItemStore};
@@ -140,6 +140,7 @@ pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<
     unrealized_finalized_checkpoint: Checkpoint,
     proposer_boost_root: Hash256,
     equivocating_indices: BTreeSet<u64>,
+    inclusion_list_equivocators: HashMap<(Slot, Hash256), BTreeSet<u64>>,
     _phantom: PhantomData<E>,
 }
 
@@ -189,6 +190,7 @@ where
             unrealized_finalized_checkpoint: finalized_checkpoint,
             proposer_boost_root: Hash256::zero(),
             equivocating_indices: BTreeSet::new(),
+            inclusion_list_equivocators: HashMap::new(),
             _phantom: PhantomData,
         })
     }
@@ -227,6 +229,7 @@ where
             unrealized_finalized_checkpoint: persisted.unrealized_finalized_checkpoint,
             proposer_boost_root: persisted.proposer_boost_root,
             equivocating_indices: persisted.equivocating_indices,
+            inclusion_list_equivocators: HashMap::new(),
             _phantom: PhantomData,
         })
     }

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -141,6 +141,7 @@ pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<
     proposer_boost_root: Hash256,
     equivocating_indices: BTreeSet<u64>,
     inclusion_list_equivocators: HashMap<(Slot, Hash256), BTreeSet<u64>>,
+    unsatisfied_inclusion_list_block: Hash256,
     _phantom: PhantomData<E>,
 }
 
@@ -191,6 +192,7 @@ where
             proposer_boost_root: Hash256::zero(),
             equivocating_indices: BTreeSet::new(),
             inclusion_list_equivocators: HashMap::new(),
+            unsatisfied_inclusion_list_block: Hash256::zero(),
             _phantom: PhantomData,
         })
     }
@@ -208,6 +210,7 @@ where
             unrealized_finalized_checkpoint: self.unrealized_finalized_checkpoint,
             proposer_boost_root: self.proposer_boost_root,
             equivocating_indices: self.equivocating_indices.clone(),
+            unsatisfied_inclusion_list_block: self.unsatisfied_inclusion_list_block,
         }
     }
 
@@ -230,6 +233,7 @@ where
             proposer_boost_root: persisted.proposer_boost_root,
             equivocating_indices: persisted.equivocating_indices,
             inclusion_list_equivocators: HashMap::new(),
+            unsatisfied_inclusion_list_block: persisted.unsatisfied_inclusion_list_block,
             _phantom: PhantomData,
         })
     }
@@ -347,6 +351,14 @@ where
     fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>) {
         self.equivocating_indices.extend(indices);
     }
+
+    fn set_unsatisfied_inclusion_list_block(&mut self, block_root: Hash256) {
+        self.unsatisfied_inclusion_list_block = block_root;
+    }
+
+    fn unsatisfied_inclusion_list_block(&self) -> Hash256 {
+        self.unsatisfied_inclusion_list_block
+    }
 }
 
 pub type PersistedForkChoiceStore = PersistedForkChoiceStoreV17;
@@ -363,4 +375,5 @@ pub struct PersistedForkChoiceStore {
     pub unrealized_finalized_checkpoint: Checkpoint,
     pub proposer_boost_root: Hash256,
     pub equivocating_indices: BTreeSet<u64>,
+    pub unsatisfied_inclusion_list_block: Hash256,
 }

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -356,8 +356,8 @@ where
         self.unsatisfied_inclusion_list_block = block_root;
     }
 
-    fn unsatisfied_inclusion_list_block(&self) -> Hash256 {
-        self.unsatisfied_inclusion_list_block
+    fn unsatisfied_inclusion_list_block(&self) -> &Hash256 {
+        &self.unsatisfied_inclusion_list_block
     }
 }
 

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -965,6 +965,7 @@ where
             validator_pubkey_cache: RwLock::new(validator_pubkey_cache),
             attester_cache: <_>::default(),
             early_attester_cache: <_>::default(),
+            inclusion_list_cache: <_>::default(),
             reqresp_pre_import_cache: <_>::default(),
             light_client_server_cache: LightClientServerCache::new(),
             light_client_server_tx: self.light_client_server_tx,

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -200,6 +200,13 @@ async fn notify_new_payload<'a, T: BeaconChainTypes>(
                     // imported to fork choice was the parent.
                     let latest_root = block.parent_root();
 
+                    // If the payload is invalid because it didn't satisfy the inclusion lit
+                    // transactions for this slot, update the fork choice store before processing
+                    // the invalid EL payload.
+                    if *validation_error == Some("INVALID_INCLUSION_LIST".to_string()) {
+                        chain.set_unsatisfied_inclusion_list_block(block.tree_hash_root()).await?;
+                    }
+
                     chain
                         .process_invalid_execution_payload(&InvalidationOperation::InvalidateMany {
                             head_block_root: latest_root,

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -205,7 +205,9 @@ async fn notify_new_payload<'a, T: BeaconChainTypes>(
                     // transactions for this slot, update the fork choice store before processing
                     // the invalid EL payload.
                     if *validation_error == Some("INVALID_INCLUSION_LIST".to_string()) {
-                        chain.set_unsatisfied_inclusion_list_block(block.tree_hash_root()).await?;
+                        chain
+                            .set_unsatisfied_inclusion_list_block(block.tree_hash_root())
+                            .await?;
                     }
 
                     chain

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -105,6 +105,7 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
 
         let inclusion_list_transactions = chain
             .inclusion_list_cache
+            .read()
             .get_inclusion_list_transactions(block.slot())
             .unwrap_or(vec![].into());
 

--- a/beacon_node/beacon_chain/src/inclusion_list_verification.rs
+++ b/beacon_node/beacon_chain/src/inclusion_list_verification.rs
@@ -29,9 +29,7 @@ impl From<BeaconChainError> for GossipInclusionListError {
 }
 
 pub struct GossipVerifiedInclusionList<T: BeaconChainTypes> {
-    // TODO(focil) remove once this field is read
-    #[allow(dead_code)]
-    signed_il: SignedInclusionList<T::EthSpec>,
+    pub signed_il: SignedInclusionList<T::EthSpec>,
 }
 
 impl<T: BeaconChainTypes> GossipVerifiedInclusionList<T> {

--- a/beacon_node/beacon_chain/src/inclusion_list_verification.rs
+++ b/beacon_node/beacon_chain/src/inclusion_list_verification.rs
@@ -29,6 +29,8 @@ impl From<BeaconChainError> for GossipInclusionListError {
 }
 
 pub struct GossipVerifiedInclusionList<T: BeaconChainTypes> {
+    // TODO(focil) remove once this field is read
+    #[allow(dead_code)]
     signed_il: SignedInclusionList<T::EthSpec>,
 }
 

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -724,6 +724,8 @@ impl HttpJsonRpc {
         .await
     }
 
+    pub async fn update_payload_with_inclusion_list<E: EthSpec>(&self) {}
+
     pub async fn get_inclusion_list<E: EthSpec>(
         &self,
         parent_hash: Hash256,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1384,6 +1384,7 @@ impl<E: EthSpec> ExecutionLayer<E> {
             );
         }
         *self.inner.last_new_payload_errored.write().await = result.is_err();
+        // TODO(focil) write block hash to some store in the case where theres an IL valdation error on newPayloadv5
 
         process_payload_status(block_hash, result, self.log())
             .map_err(Box::new)

--- a/beacon_node/http_api/src/inclusion_list_duties.rs
+++ b/beacon_node/http_api/src/inclusion_list_duties.rs
@@ -1,4 +1,4 @@
-use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2::types::{self as api_types};
 use slot_clock::SlotClock;
 use types::{Epoch, EthSpec, Hash256, InclusionListDuty};

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2258,7 +2258,8 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // POST beacon/pool/inclusion_lists
-    let post_beacon_pool_inclusion_lists = beacon_pool_path
+    // TODO(focil) unused endpoint and variables
+    let _post_beacon_pool_inclusion_lists = beacon_pool_path
         .clone()
         .and(warp::path("inclusion_lists"))
         .and(warp::path::end())
@@ -2267,12 +2268,12 @@ pub fn serve<T: BeaconChainTypes>(
         .and(log_filter.clone())
         .then(
             |task_spawner: TaskSpawner<T::EthSpec>,
-             chain: Arc<BeaconChain<T>>,
+             _chain: Arc<BeaconChain<T>>,
              inclusion_lists: Vec<SignedInclusionList<T::EthSpec>>,
-             network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
+             _network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
              log: Logger| {
                 task_spawner.blocking_json_task(Priority::P0, move || {
-                    // TODO: actually gossip the inclusion lists
+                    // TODO(focil): actually gossip the inclusion lists
                     info!(
                         log,
                         "Posting signed inclusion lists for gossip";
@@ -3547,7 +3548,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     // allow a tolerance of one slot to account for clock skew
                     //
-                    // TODO: make sure tolerance is consistent with inner logic
+                    // TODO(focil) make sure tolerance is consistent with inner logic
                     if query.slot > current_slot + 1 {
                         return Err(warp_utils::reject::custom_bad_request(format!(
                             "request slot {} is more than one slot past the current slot {}",
@@ -3558,7 +3559,6 @@ pub fn serve<T: BeaconChainTypes>(
                     let data = chain
                         .produce_inclusion_list(query.slot)
                         .await
-                        .map(|il| il.clone())
                         .map(api_types::GenericResponse::from)
                         .map_err(warp_utils::reject::beacon_chain_error)?;
                     Ok::<_, warp::reject::Rejection>(warp::reply::json(&data).into_response())

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -2165,15 +2165,16 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         };
     }
 
+    // TODO(focil) unused variables
     pub fn process_gossip_inclusion_list(
         self: &Arc<Self>,
-        message_id: MessageId,
-        peer_id: PeerId,
+        _message_id: MessageId,
+        _peer_id: PeerId,
         il: SignedInclusionList<T::EthSpec>,
-        seen_timestamp: Duration,
+        _seen_timestamp: Duration,
     ) {
         match GossipVerifiedInclusionList::verify(&il, &self.chain) {
-            Ok(gossip_verified_il) => {
+            Ok(_gossip_verified_il) => {
                 debug!(self.log, "Successfully verified gossip inclusion list");
             }
             Err(err) => match err {

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -2178,7 +2178,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 debug!(self.log, "Successfully verified gossip inclusion list");
                 // Store validated inclusion list in the IL cache. This also catches
                 // equivocating IL's and handles them accordingly.
-                self.chain.on_verified_inclusion_list(gossip_verified_il.signed_il);
+                self.chain
+                    .on_verified_inclusion_list(gossip_verified_il.signed_il);
             }
             Err(err) => match err {
                 GossipInclusionListError::FutureSlot { .. }

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -2174,8 +2174,11 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         _seen_timestamp: Duration,
     ) {
         match GossipVerifiedInclusionList::verify(&il, &self.chain) {
-            Ok(_gossip_verified_il) => {
+            Ok(gossip_verified_il) => {
                 debug!(self.log, "Successfully verified gossip inclusion list");
+                // Store validated inclusion list in the IL cache. This also catches
+                // equivocating IL's and handles them accordingly.
+                self.chain.on_verified_inclusion_list(gossip_verified_il.signed_il);
             }
             Err(err) => match err {
                 GossipInclusionListError::FutureSlot { .. }

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -541,8 +541,8 @@ impl<T: BeaconChainTypes> Router<T> {
                             bls_to_execution_change,
                         ),
                 ),
-            PubsubMessage::InclusionList(il) => {
-                // TODO
+            PubsubMessage::InclusionList(_il) => {
+                // TODO(focil)
             }
         }
     }

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -489,6 +489,7 @@ where
             store.justified_balances(),
             store.proposer_boost_root(),
             store.equivocating_indices(),
+            store.unsatisfied_inclusion_list_block(),
             current_slot,
             spec,
         )?;
@@ -624,6 +625,14 @@ where
         self.proto_array
             .process_execution_payload_invalidation::<E>(op)
             .map_err(Error::FailedToProcessInvalidExecutionPayload)
+    }
+
+    // TODO(focil) add documentation
+     pub fn on_invalid_inclusion_list_payload(
+        &mut self,
+        block_root: Hash256,
+    ) {
+        self.fc_store.set_unsatisfied_inclusion_list_block(block_root);
     }
 
     /// Add `block` to the fork choice DAG.

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -390,6 +390,7 @@ where
             *fc_store.finalized_checkpoint(),
             current_epoch_shuffling_id,
             next_epoch_shuffling_id,
+            *fc_store.unsatisfied_inclusion_list_block(),
             execution_status,
         )?;
 
@@ -489,7 +490,6 @@ where
             store.justified_balances(),
             store.proposer_boost_root(),
             store.equivocating_indices(),
-            store.unsatisfied_inclusion_list_block(),
             current_slot,
             spec,
         )?;
@@ -628,11 +628,9 @@ where
     }
 
     // TODO(focil) add documentation
-     pub fn on_invalid_inclusion_list_payload(
-        &mut self,
-        block_root: Hash256,
-    ) {
-        self.fc_store.set_unsatisfied_inclusion_list_block(block_root);
+    pub fn on_invalid_inclusion_list_payload(&mut self, block_root: Hash256) {
+        self.fc_store
+            .set_unsatisfied_inclusion_list_block(block_root);
     }
 
     /// Add `block` to the fork choice DAG.

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -79,4 +79,10 @@ pub trait ForkChoiceStore<E: EthSpec>: Sized {
 
     /// Adds to the set of equivocating indices.
     fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>);
+
+    /// Returns the `unsatisfied_inclusion_list_block`.
+    fn unsatisfied_inclusion_list_block(&self) -> Hash256;
+
+    /// Sets the `unsatisfied_inclusion_list_block`.
+    fn set_unsatisfied_inclusion_list_block(&mut self, block_root: Hash256);
 }

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -81,7 +81,7 @@ pub trait ForkChoiceStore<E: EthSpec>: Sized {
     fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>);
 
     /// Returns the `unsatisfied_inclusion_list_block`.
-    fn unsatisfied_inclusion_list_block(&self) -> Hash256;
+    fn unsatisfied_inclusion_list_block(&self) -> &Hash256;
 
     /// Sets the `unsatisfied_inclusion_list_block`.
     fn set_unsatisfied_inclusion_list_block(&mut self, block_root: Hash256);

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -87,6 +87,7 @@ impl ForkChoiceTestDefinition {
             self.finalized_checkpoint,
             junk_shuffling_id.clone(),
             junk_shuffling_id,
+            Hash256::ZERO,
             ExecutionStatus::Optimistic(ExecutionBlockHash::zero()),
         )
         .expect("should create fork choice struct");
@@ -110,7 +111,6 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             Hash256::zero(),
                             &equivocating_indices,
-                            Hash256::zero(),
                             Slot::new(0),
                             &spec,
                         )
@@ -142,7 +142,6 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             proposer_boost_root,
                             &equivocating_indices,
-                            Hash256::zero(),
                             Slot::new(0),
                             &spec,
                         )
@@ -171,7 +170,6 @@ impl ForkChoiceTestDefinition {
                         &justified_balances,
                         Hash256::zero(),
                         &equivocating_indices,
-                        Hash256::zero(),
                         Slot::new(0),
                         &spec,
                     );

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -110,6 +110,7 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             Hash256::zero(),
                             &equivocating_indices,
+                            Hash256::zero(),
                             Slot::new(0),
                             &spec,
                         )
@@ -141,6 +142,7 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             proposer_boost_root,
                             &equivocating_indices,
+                            Hash256::zero(),
                             Slot::new(0),
                             &spec,
                         )
@@ -169,6 +171,7 @@ impl ForkChoiceTestDefinition {
                         &justified_balances,
                         Hash256::zero(),
                         &equivocating_indices,
+                        Hash256::zero(),
                         Slot::new(0),
                         &spec,
                     );

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -159,6 +159,7 @@ impl ProtoArray {
         finalized_checkpoint: Checkpoint,
         new_justified_balances: &JustifiedBalances,
         proposer_boost_root: Hash256,
+        unsatisfied_inclusion_list_block: Hash256,
         current_slot: Slot,
         spec: &ChainSpec,
     ) -> Result<(), Error> {
@@ -195,17 +196,20 @@ impl ProtoArray {
 
             let execution_status_is_invalid = node.execution_status.is_invalid();
 
-            let mut node_delta = if execution_status_is_invalid {
-                // If the node has an invalid execution payload, reduce its weight to zero.
-                0_i64
-                    .checked_sub(node.weight as i64)
-                    .ok_or(Error::InvalidExecutionDeltaOverflow(node_index))?
-            } else {
-                deltas
-                    .get(node_index)
-                    .copied()
-                    .ok_or(Error::InvalidNodeDelta(node_index))?
-            };
+            // TODO(focil) seems sketchy...
+            let mut node_delta =
+                if execution_status_is_invalid || node.root == unsatisfied_inclusion_list_block {
+                    // If the node has an invalid execution payload, or the payload doesn't satisfy
+                    // an inclusion list, reduce its weight to zero.
+                    0_i64
+                        .checked_sub(node.weight as i64)
+                        .ok_or(Error::InvalidExecutionDeltaOverflow(node_index))?
+                } else {
+                    deltas
+                        .get(node_index)
+                        .copied()
+                        .ok_or(Error::InvalidNodeDelta(node_index))?
+                };
 
             // If we find the node for which the proposer boost was previously applied, decrease
             // the delta by the previous score amount.

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -467,6 +467,7 @@ impl ProtoArrayForkChoice {
         justified_state_balances: &JustifiedBalances,
         proposer_boost_root: Hash256,
         equivocating_indices: &BTreeSet<u64>,
+        unsatisfied_inclusion_list_block: Hash256,
         current_slot: Slot,
         spec: &ChainSpec,
     ) -> Result<Hash256, String> {
@@ -489,6 +490,7 @@ impl ProtoArrayForkChoice {
                 finalized_checkpoint,
                 new_balances,
                 proposer_boost_root,
+                unsatisfied_inclusion_list_block,
                 current_slot,
                 spec,
             )

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -370,6 +370,7 @@ impl ProtoArrayForkChoice {
         finalized_checkpoint: Checkpoint,
         current_epoch_shuffling_id: AttestationShufflingId,
         next_epoch_shuffling_id: AttestationShufflingId,
+        unsatisfied_inclusion_list_block: Hash256,
         execution_status: ExecutionStatus,
     ) -> Result<Self, String> {
         let mut proto_array = ProtoArray {
@@ -378,6 +379,7 @@ impl ProtoArrayForkChoice {
             finalized_checkpoint,
             nodes: Vec::with_capacity(1),
             indices: HashMap::with_capacity(1),
+            unsatisfied_inclusion_list_block,
             previous_proposer_boost: ProposerBoost::default(),
         };
 
@@ -467,7 +469,6 @@ impl ProtoArrayForkChoice {
         justified_state_balances: &JustifiedBalances,
         proposer_boost_root: Hash256,
         equivocating_indices: &BTreeSet<u64>,
-        unsatisfied_inclusion_list_block: Hash256,
         current_slot: Slot,
         spec: &ChainSpec,
     ) -> Result<Hash256, String> {
@@ -490,7 +491,6 @@ impl ProtoArrayForkChoice {
                 finalized_checkpoint,
                 new_balances,
                 proposer_boost_root,
-                unsatisfied_inclusion_list_block,
                 current_slot,
                 spec,
             )
@@ -1033,6 +1033,7 @@ mod test_compute_deltas {
             genesis_checkpoint,
             junk_shuffling_id.clone(),
             junk_shuffling_id.clone(),
+            Hash256::ZERO,
             execution_status,
         )
         .unwrap();
@@ -1159,6 +1160,7 @@ mod test_compute_deltas {
             genesis_checkpoint,
             junk_shuffling_id.clone(),
             junk_shuffling_id.clone(),
+            Hash256::ZERO,
             execution_status,
         )
         .unwrap();

--- a/consensus/proto_array/src/ssz_container.rs
+++ b/consensus/proto_array/src/ssz_container.rs
@@ -27,6 +27,7 @@ pub struct SszContainer {
     pub nodes: Vec<ProtoNodeV17>,
     pub indices: Vec<(Hash256, usize)>,
     pub previous_proposer_boost: ProposerBoost,
+    pub unsatisfied_inclusion_list_block: Hash256,
 }
 
 impl From<&ProtoArrayForkChoice> for SszContainer {
@@ -42,6 +43,7 @@ impl From<&ProtoArrayForkChoice> for SszContainer {
             nodes: proto_array.nodes.clone(),
             indices: proto_array.indices.iter().map(|(k, v)| (*k, *v)).collect(),
             previous_proposer_boost: proto_array.previous_proposer_boost,
+            unsatisfied_inclusion_list_block: proto_array.unsatisfied_inclusion_list_block,
         }
     }
 }
@@ -56,6 +58,7 @@ impl TryFrom<SszContainer> for ProtoArrayForkChoice {
             finalized_checkpoint: from.finalized_checkpoint,
             nodes: from.nodes,
             indices: from.indices.into_iter().collect::<HashMap<_, _>>(),
+            unsatisfied_inclusion_list_block: from.unsatisfied_inclusion_list_block,
             previous_proposer_boost: from.previous_proposer_boost,
         };
 

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -28,6 +28,7 @@ pub use self::committee_cache::{
 };
 pub use crate::beacon_state::balance::Balance;
 pub use crate::beacon_state::exit_cache::ExitCache;
+pub use crate::beacon_state::inclusion_list_cache::InclusionListCache;
 pub use crate::beacon_state::progressive_balances_cache::*;
 pub use crate::beacon_state::slashings_cache::SlashingsCache;
 pub use eth_spec::*;
@@ -38,6 +39,7 @@ pub use milhouse::{interface::Interface, List, Vector};
 mod committee_cache;
 mod balance;
 mod exit_cache;
+mod inclusion_list_cache;
 mod iter;
 mod progressive_balances_cache;
 mod pubkey_cache;

--- a/consensus/types/src/beacon_state/inclusion_list_cache.rs
+++ b/consensus/types/src/beacon_state/inclusion_list_cache.rs
@@ -1,0 +1,91 @@
+use std::collections::{HashMap, HashSet};
+
+use super::{EthSpec, InclusionListTransactions, SignedInclusionList, Slot, Transaction};
+
+/// Map from slot to inclusion lists
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct InclusionListCache<E: EthSpec> {
+    inner_map: HashMap<Slot, Inner<E>>,
+}
+
+type ValidatorIndex = u64;
+
+#[derive(Debug, Default, Clone, PartialEq)]
+struct Inner<E: EthSpec> {
+    pub inclusion_lists: HashSet<SignedInclusionList<E>>,
+    pub inclusion_lists_seen: HashSet<ValidatorIndex>,
+    pub inclusion_list_equivocators: HashSet<ValidatorIndex>,
+    pub inclusion_list_transactions: HashSet<Transaction<E::MaxBytesPerTransaction>>,
+}
+
+impl<E: EthSpec> InclusionListCache<E> {
+    pub fn initialize(&mut self, slot: Slot) {
+        let inner = Inner {
+            inclusion_lists: HashSet::new(),
+            inclusion_lists_seen: HashSet::new(),
+            inclusion_list_equivocators: HashSet::new(),
+            inclusion_list_transactions: HashSet::new(),
+        };
+
+        self.inner_map.insert(slot, inner);
+    }
+
+    pub fn clear_cache(&mut self, slot: Slot) {
+        self.inner_map.remove(&slot);
+    }
+
+    pub fn on_inclusion_list(&mut self, inclusion_list: SignedInclusionList<E>) {
+        let Some(inner) = self.inner_map.get_mut(&inclusion_list.message.slot) else {
+            return;
+        };
+
+        if inner
+            .inclusion_list_equivocators
+            .contains(&inclusion_list.message.validator_index)
+        {
+            return;
+        }
+
+        if inner.inclusion_lists_seen.contains(&inclusion_list.message.validator_index) && !inner.inclusion_lists.contains(&inclusion_list) {
+            inner
+                .inclusion_list_equivocators
+                .insert(inclusion_list.message.validator_index);
+            return;
+        }
+
+        // Skip inserting into the cache if we've already seen an identical IL
+        if inner.inclusion_lists_seen.contains(&inclusion_list.message.validator_index) && inner.inclusion_lists.contains(&inclusion_list) {
+            return;
+        }
+
+        for transaction in &inclusion_list.message.transactions {
+            inner
+                .inclusion_list_transactions
+                .insert(transaction.clone());
+        }
+        inner.inclusion_lists_seen.insert(inclusion_list.message.validator_index);
+        inner.inclusion_lists.insert(inclusion_list);
+    }
+
+    pub fn get_inclusion_list_transactions(
+        &self,
+        slot: Slot,
+    ) -> Option<InclusionListTransactions<E>> {
+        let Some(inner) = &self.inner_map.get(&slot) else {
+            return None;
+        };
+
+        let il = inner
+            .inclusion_list_transactions
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        Some(il.into())
+    }
+}
+
+impl<E: EthSpec> arbitrary::Arbitrary<'_> for InclusionListCache<E> {
+    fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self::default())
+    }
+}

--- a/consensus/types/src/beacon_state/inclusion_list_cache.rs
+++ b/consensus/types/src/beacon_state/inclusion_list_cache.rs
@@ -46,7 +46,11 @@ impl<E: EthSpec> InclusionListCache<E> {
             return;
         }
 
-        if inner.inclusion_lists_seen.contains(&inclusion_list.message.validator_index) && !inner.inclusion_lists.contains(&inclusion_list) {
+        if inner
+            .inclusion_lists_seen
+            .contains(&inclusion_list.message.validator_index)
+            && !inner.inclusion_lists.contains(&inclusion_list)
+        {
             inner
                 .inclusion_list_equivocators
                 .insert(inclusion_list.message.validator_index);
@@ -54,7 +58,11 @@ impl<E: EthSpec> InclusionListCache<E> {
         }
 
         // Skip inserting into the cache if we've already seen an identical IL
-        if inner.inclusion_lists_seen.contains(&inclusion_list.message.validator_index) && inner.inclusion_lists.contains(&inclusion_list) {
+        if inner
+            .inclusion_lists_seen
+            .contains(&inclusion_list.message.validator_index)
+            && inner.inclusion_lists.contains(&inclusion_list)
+        {
             return;
         }
 
@@ -63,7 +71,9 @@ impl<E: EthSpec> InclusionListCache<E> {
                 .inclusion_list_transactions
                 .insert(transaction.clone());
         }
-        inner.inclusion_lists_seen.insert(inclusion_list.message.validator_index);
+        inner
+            .inclusion_lists_seen
+            .insert(inclusion_list.message.validator_index);
         inner.inclusion_lists.insert(inclusion_list);
     }
 

--- a/consensus/types/src/inclusion_list.rs
+++ b/consensus/types/src/inclusion_list.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
 use test_random_derive::TestRandom;
-use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
 pub type InclusionListTransactions<E> = VariableList<

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -1441,7 +1441,8 @@ async fn poll_beacon_inclusion_list_duties_for_epoch<T: SlotClock + 'static, E: 
 
     // Update the duties service with the new `InclusionListDutyData` messages.
     let mut inclusion_list_duties = duties_service.inclusion_list_duties.write();
-    let current_slot = duties_service
+    // TODO(focil) this variable is unused at the moment
+    let _current_slot = duties_service
         .slot_clock
         .now_or_genesis()
         .unwrap_or_default();
@@ -1451,7 +1452,8 @@ async fn poll_beacon_inclusion_list_duties_for_epoch<T: SlotClock + 'static, E: 
         match inclusion_list_duty_map.entry(epoch) {
             hash_map::Entry::Occupied(mut occupied) => {
                 let mut_value = occupied.get_mut();
-                let (prior_dependent_root, prior_duty) = &mut_value;
+                // TODO(focil) unused variable
+                let (prior_dependent_root, _prior_duty) = &mut_value;
 
                 // NOTE: We do not need to worry about an overwrite here, since there is no
                 // information that we store aside from the duty itself. There is no selection proof


### PR DESCRIPTION
22615169d01a17c91002a91d6510c3e13b2ecdb4 introduces an inclusion list cache. The cache should be used to store verified inclusion lists and should also have some process to evict stale inclusion list data. `notify_new_payload` uses is updated to use the inclusion list cache to fetch a valid payload from the EL. 

The main thing left for fork choice changes are `get_attester_head` changes in the situation where the potential head block to be attested on is in `unsatisfied_inclusion_list_blocks`. This PR also doesnt currently populate the IL cache with any data